### PR TITLE
Fix tying/trying typos in chapter6

### DIFF
--- a/chapter6/amp.html
+++ b/chapter6/amp.html
@@ -319,7 +319,7 @@ nav a[rel="next"] cite span {
 <p>Taking an <abbr>x</abbr>‐ray perspective means looking “through” the complex widgets and visual styles of a design, identifying the core content and functional pieces that make up the page, and finding a simple <abbr>HTML</abbr> equivalent for each that will work universally.</p>
 </blockquote>
 
-<p>If you’re not used to this approach to web design, it can take some getting used to. But after a while it becomes a habit and then it’s hard <em>not</em> to examine interfaces in this way. It’s like trying not to notice bad kerning, or tying not to see the arrow in the whitespace of the FedEx logo, or trying to not to remember that all ducks are actually wearing dog masks.</p>
+<p>If you’re not used to this approach to web design, it can take some getting used to. But after a while it becomes a habit and then it’s hard <em>not</em> to examine interfaces in this way. It’s like trying not to notice bad kerning, or trying not to see the arrow in the whitespace of the FedEx logo, or trying to not to remember that all ducks are actually wearing dog masks.</p>
 
 <figure>
 <amp-img src="images/small/duck.jpg" alt="Close up of a duck." srcset="images/medium/duck.jpg 2x, images/large/duck.jpg 3x" width="400" height="268">

--- a/chapter6/index.html
+++ b/chapter6/index.html
@@ -52,7 +52,7 @@
 <p>Taking an <abbr>x</abbr>‐ray perspective means looking “through” the complex widgets and visual styles of a design, identifying the core content and functional pieces that make up the page, and finding a simple <abbr>HTML</abbr> equivalent for each that will work universally.</p>
 </blockquote>
 
-<p>If you’re not used to this approach to web design, it can take some getting used to. But after a while it becomes a habit and then it’s hard <em>not</em> to examine interfaces in this way. It’s like trying not to notice bad kerning, or tying not to see the arrow in the whitespace of the FedEx logo, or trying to not to remember that all ducks are actually wearing dog masks.</p>
+<p>If you’re not used to this approach to web design, it can take some getting used to. But after a while it becomes a habit and then it’s hard <em>not</em> to examine interfaces in this way. It’s like trying not to notice bad kerning, or trying not to see the arrow in the whitespace of the FedEx logo, or trying to not to remember that all ducks are actually wearing dog masks.</p>
 
 <figure>
 <picture>


### PR DESCRIPTION
This replaces:

> tying not to see the arrow in the whitespace of the FedEx logo

with

> trying not to see the arrow in the whitespace of the FedEx logo