### PR TITLE
replace whitespace characters in text also

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -15,7 +15,7 @@ function getElementsByText(scope, text) {
     // iterate descendants of scope
     for (var all = scope.childNodes, index = 0, element, list = []; (element = all[index]); ++index) {
         // conditionally return element containing visible, whitespace-insensitive, case-sensitive text (a match)
-        if (element.nodeType === 1 && (element.innerText || element.textContent || '').replace(/\s+/g, ' ').indexOf(text) !== -1) {
+        if (element.nodeType === 1 && (element.innerText || element.textContent || '').replace(/\s+/g, ' ').indexOf(text.replace(/\s+/g, ' ')) !== -1) {
             list = list.concat(getElementsByText(element, text));
         }
     }


### PR DESCRIPTION
per https://adactio.com/journal/11632

> Any selected text that includes the last two words of a paragraph fails to match. I’ve tried tweaking the script, but I’m stumped. If you fancy having a go, please have at it.

I'll take a stab.

What I'm seeing is the text that gets passed in the #hash has a non-breaking space character in between the last two words, which matches the markup.

However, in `getElementsByText` the passed `text` is being compared to the `.innerText` or `.textContent` of the node like so:

```js
(element.innerText || element.textContent || '').replace(/\s+/g, ' ').indexOf(text)
```

`.replace(/\s+/g, ' ')` will find any whitespace character, crucially _including non-breaking space characters_, and replace them all with a regular space.

However `text` in `.indexOf(text)` will still have the non-breaking space. So the strings will be technically different and you won't find a match.

Run the same `.replace(/\s+/g, ' ')` on both the element's innerText and the passed  `text` and it appears to work.

(You might also be able to lose the replace in both places, but I imagine it's there for a reason.)